### PR TITLE
Allow more fine-grained logging from gssapi plugin

### DIFF
--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -1264,7 +1264,7 @@ gssapi_server_mech_step(void *conn_context,
 
     if (text == NULL) return SASL_BADPROT;
 
-    params->utils->log(NULL, SASL_LOG_DEBUG,
+    params->utils->log(params->utils->conn, SASL_LOG_DEBUG,
 		       "GSSAPI server step %d\n", text->state);
 
     switch (text->state) {
@@ -1290,7 +1290,7 @@ gssapi_server_mech_step(void *conn_context,
 	break;
 
     default:
-	params->utils->log(NULL, SASL_LOG_ERR,
+	params->utils->log(params->utils->conn, SASL_LOG_ERR,
 			   "Invalid GSSAPI server step %d\n", text->state);
 	return SASL_FAIL;
     }
@@ -1496,7 +1496,7 @@ static int gssapi_client_mech_step(void *conn_context,
     *clientout = NULL;
     *clientoutlen = 0;
     
-    params->utils->log(NULL, SASL_LOG_DEBUG,
+    params->utils->log(params->utils->conn, SASL_LOG_DEBUG,
 		       "GSSAPI client step %d", text->state);
 
     switch (text->state) {
@@ -1989,7 +1989,7 @@ static int gssapi_client_mech_step(void *conn_context,
     }
 	
     default:
-	params->utils->log(NULL, SASL_LOG_ERR,
+	params->utils->log(params->utils->conn, SASL_LOG_ERR,
 			   "Invalid GSSAPI client step %d\n", text->state);
 	return SASL_FAIL;
     }


### PR DESCRIPTION
Based on report in Red Hat bugzilla [2] and discussion in upstream mailing list [2]
it is obvious, that there is no mechanism to stop logging of some verbose messages.
This patch is providing context to logger, which can involve application-defined
callbacks and potentially reduce amount of logged messages.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1187097
[2] http://lists.andrew.cmu.edu/pipermail/cyrus-sasl/2015-January/002785.html
