### PR TITLE
Support AIX SASL GSSAPI

### DIFF
--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -1183,19 +1183,18 @@ gssapi_server_mech_ssfreq(context_t *text,
     }
 
     layerchoice = (int)(((char *)(output_token->value))[0]);
-    if (layerchoice == LAYER_NONE &&
+    if (!(layerchoice & (LAYER_INTEGRITY | LAYER_CONFIDENTIALITY)) &&
 	(text->qop & LAYER_NONE)) { /* no encryption */
 	oparams->encode = NULL;
 	oparams->decode = NULL;
 	oparams->mech_ssf = 0;
-    } else if (layerchoice == LAYER_INTEGRITY &&
+    } else if ((layerchoice & LAYER_INTEGRITY) &&
 	       (text->qop & LAYER_INTEGRITY)) { /* integrity */
 	oparams->encode = &gssapi_integrity_encode;
 	oparams->decode = &gssapi_decode;
 	oparams->mech_ssf = 1;
-    } else if ((layerchoice == LAYER_CONFIDENTIALITY ||
-		/* For compatibility with broken clients setting both bits */
-		layerchoice == (LAYER_CONFIDENTIALITY|LAYER_INTEGRITY)) &&
+    } else if (/* For compatibility with broken clients setting both bits */
+		(layerchoice & (LAYER_CONFIDENTIALITY | LAYER_INTEGRITY)) &&
 	       (text->qop & LAYER_CONFIDENTIALITY)) { /* privacy */
 	oparams->encode = &gssapi_privacy_encode;
 	oparams->decode = &gssapi_decode;


### PR DESCRIPTION
When choosing protection layer in `gssapi_server_mech_ssfreq()`, we are acceptor already and this means `SentByAcceptor` bit is cleared. If acceptor receives a token with `SentByAcceptor` bit set, this is wrong and therefore must cause SASL negotiation to fail.

Original code used `LAYER_NONE` constant (equal to 1) wrongly here.

Original patch from Alexander Bokovoy abokovoy@redhat.com
