### PR TITLE
saslauthd: Fix indentation to silent GCC6 warnings [-Wmisleading-indentation]

### DIFF
--- a/saslauthd/lak.c
+++ b/saslauthd/lak.c
@@ -1378,8 +1378,8 @@ static int lak_group_member(
     }
 
 done:;
-	if (res)
-		ldap_msgfree(res);
+    if (res)
+        ldap_msgfree(res);
     if (group_dn)
         free(group_dn);
     if (group_filter)
@@ -1391,7 +1391,7 @@ done:;
     if (dn_bv)
         ber_bvfree(dn_bv);
 
-	return rc;
+    return rc;
 }
 
 static int lak_auth_custom(


### PR DESCRIPTION
Example warning from the build on Fedora 26 (Rawhide):
```
gcc -DHAVE_CONFIG_H -DSASLAUTHD_CONF_FILE_DEFAULT=\"/etc/saslauthd.conf\" -I. -I. -I.. -I.  -I./include -I./include -I./../include -I/usr/include/mysql    -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic  -I/usr/include/mysql   -fPIC -pie -Wl,-z,relro -Wl,-z,now -c -o lak.o lak.c
lak.c: In function 'lak_group_member':
lak.c:1420:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if (dn_bv)
     ^~
lak.c:1423:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  return rc;
  ^~~~~~
```